### PR TITLE
feat: update Chrome extension manifest to V3.

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,12 +1,15 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Butler",
   "version": "0.0.2",
   "description": "Butler is the Chrome extension to search tabs & browser histories.",
   "permissions": ["tabs", "history", "storage"],
-  "browser_action": {
+  "action": {
     "default_title": "Butler",
     "default_popup": "index.html"
+  },
+  "content_security_policy": {
+    "extension_pages": "script-src 'self'; object-src 'self';"
   },
   "icons": {
     "16": "assets/butler_16.png",


### PR DESCRIPTION
This involved migrating the extension manifest from Manifest V2 to Manifest V3.

Here are the key changes I made:
- I updated `manifest_version` to 3.
- I replaced `browser_action` with `action`.
- I added a `content_security_policy` for `extension_pages` set to a strict default: `"script-src 'self'; object-src 'self';"`.
- I verified that your existing `permissions`, `icons`, and `options_ui` are V3 compatible.

I then successfully built the project and all tests passed after these changes.