### PR TITLE
feat: Partially migrate to standalone components

### DIFF
--- a/projects/options/src/app/app.component.ts
+++ b/projects/options/src/app/app.component.ts
@@ -1,5 +1,11 @@
 import { Component, OnInit } from '@angular/core'
-import { MatSlideToggleChange } from '@angular/material/slide-toggle'
+import { CommonModule } from '@angular/common'
+import {
+  MatSlideToggleChange,
+  MatSlideToggleModule,
+} from '@angular/material/slide-toggle'
+import { MatFormFieldModule } from '@angular/material/form-field'
+import { MatInputModule } from '@angular/material/input'
 import { ChromeSharedOptionsService } from 'chrome-shared-options'
 
 function fixWrongInputDate(wrongDate: Date): Date {
@@ -23,6 +29,13 @@ function getYYYYMMDD(unixEpoch: number | Date): string {
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatSlideToggleModule,
+    MatFormFieldModule,
+    MatInputModule,
+  ],
 })
 export class AppComponent implements OnInit {
   title = 'options'

--- a/projects/options/src/app/app.module.ts
+++ b/projects/options/src/app/app.module.ts
@@ -8,8 +8,9 @@ import { MatFormFieldModule } from '@angular/material/form-field'
 import { MatInputModule } from '@angular/material/input'
 
 @NgModule({
-  declarations: [AppComponent],
+  declarations: [],
   imports: [
+    AppComponent,
     BrowserModule,
     BrowserAnimationsModule,
     MatSlideToggleModule,

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,12 +1,25 @@
 import { TestBed, waitForAsync } from '@angular/core/testing'
 import { AppComponent } from './app.component'
-import { MatLegacyFormFieldModule as MatFormFieldModule } from '@angular/material/legacy-form-field'
+import { ReactiveFormsModule } from '@angular/forms'
+import { MatFormFieldModule } from '@angular/material/form-field'
+import { MatInputModule } from '@angular/material/input'
+import { MatListModule } from '@angular/material/list'
+import { MatIconModule } from '@angular/material/icon'
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 
 describe('AppComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [MatFormFieldModule],
-      declarations: [AppComponent],
+      imports: [
+        AppComponent, // Import the standalone component
+        ReactiveFormsModule,
+        MatFormFieldModule,
+        MatInputModule,
+        MatListModule,
+        MatIconModule,
+        BrowserAnimationsModule, // Often needed for Material components in tests
+      ],
+      // No declarations for standalone components
     }).compileComponents()
   }))
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,8 +1,13 @@
 import { Component, OnInit } from '@angular/core'
-import { UntypedFormControl } from '@angular/forms'
+import { CommonModule } from '@angular/common'
+import { RouterOutlet } from '@angular/router'
+import { UntypedFormControl, ReactiveFormsModule } from '@angular/forms'
 import { Observable } from 'rxjs'
 import { map, switchMap, tap } from 'rxjs/operators'
-import { MatSelectionListChange } from '@angular/material/list'
+import { MatSelectionListChange, MatListModule } from '@angular/material/list'
+import { MatFormFieldModule } from '@angular/material/form-field'
+import { MatInputModule } from '@angular/material/input'
+import { MatIconModule } from '@angular/material/icon'
 import { ChromeService } from './chrome.service'
 import Fuse from 'fuse.js'
 import { ChromeSharedOptionsService } from 'chrome-shared-options'
@@ -45,6 +50,16 @@ function isBrowserAction(
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.scss'],
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterOutlet,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatListModule,
+    MatIconModule,
+  ],
 })
 export class AppComponent implements OnInit {
   title = 'butler'

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -12,8 +12,9 @@ import { ChromeSharedOptionsModule } from 'chrome-shared-options'
 import { MatIconModule } from '@angular/material/icon'
 
 @NgModule({
-  declarations: [AppComponent],
+  declarations: [],
   imports: [
+    AppComponent,
     BrowserModule,
     BrowserAnimationsModule,
     MatFormFieldModule,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,13 +1,31 @@
-import { enableProdMode } from '@angular/core'
-import { platformBrowserDynamic } from '@angular/platform-browser-dynamic'
+import { enableProdMode, importProvidersFrom } from '@angular/core'
+import { bootstrapApplication, BrowserModule } from '@angular/platform-browser'
 
-import { AppModule } from './app/app.module'
+import { AppComponent } from './app/app.component'
 import { environment } from './environments/environment'
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
+import { MatFormFieldModule } from '@angular/material/form-field'
+import { MatInputModule } from '@angular/material/input'
+import { MatListModule } from '@angular/material/list'
+import { ReactiveFormsModule } from '@angular/forms'
+import { ChromeSharedOptionsModule } from 'chrome-shared-options'
+import { MatIconModule } from '@angular/material/icon'
 
 if (environment.production) {
   enableProdMode()
 }
 
-platformBrowserDynamic()
-  .bootstrapModule(AppModule)
-  .catch((err) => console.error(err))
+bootstrapApplication(AppComponent, {
+  providers: [
+    importProvidersFrom(
+      BrowserModule,
+      BrowserAnimationsModule,
+      MatFormFieldModule,
+      MatInputModule,
+      ReactiveFormsModule,
+      MatListModule,
+      ChromeSharedOptionsModule,
+      MatIconModule,
+    ),
+  ],
+}).catch((err) => console.error(err))


### PR DESCRIPTION

This commit includes the initial steps towards migrating your application to use Angular standalone components.

Changes so far:

1.  I installed project dependencies.
2.  I refactored the main application's `AppComponent` (located in `src/app`) to be a standalone component.
    - I modified `src/app/app.component.ts` to set `standalone: true` and import necessary dependencies.
    - I updated `src/app/app.module.ts` to remove `AppComponent` from declarations and add it to imports.
    - I updated `src/main.ts` to use `bootstrapApplication` with the standalone `AppComponent` and `importProvidersFrom` for module-level providers.
    - I verified these changes by building and testing successfully.
3.  I refactored the `AppComponent` within the `projects/options` project (located in `projects/options/src/app`) to be standalone.
    - I modified `projects/options/src/app/app.component.ts` to set `standalone: true` and import necessary dependencies like `CommonModule` and Angular Material modules.
    - I updated `projects/options/src/app/app.module.ts` to remove its `AppComponent` from declarations and add it to imports.

The next step was to update `projects/options/src/main.ts` to use `bootstrapApplication` for its standalone `AppComponent` and then verify all changes for the `options` project.